### PR TITLE
Add problematic links to ignore config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ parse:
 
 sphinx:
   config:
-    linkcheck_ignore: ["https://doi.org/*"] # don't run link checker on DOI links since they are immutable
+    linkcheck_ignore: ["https://doi.org/*","https://postimg.cc/*"] # don't run link checker on DOI links since they are immutable and ignore these other problematic links
     nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: "%-d %B %Y"


### PR DESCRIPTION
Not sure if there's a better option than ignoring these links, but this should at least stop the false alarms on the link check.

Closes #26