### PR TITLE
Adjust subsetting parameters to avoid triggering an error

### DIFF
--- a/notebooks/03-plotting-with-uxarray/high-res.ipynb
+++ b/notebooks/03-plotting-with-uxarray/high-res.ipynb
@@ -139,7 +139,7 @@
    "cell_type": "code",
    "source": [
     "relhum_subset = uxds[\"relhum_200hPa\"][0].subset.bounding_box(\n",
-    "    lon_bounds=[-0.5, 0.5], lat_bounds=[-0.25, 0.25]\n",
+    "    lon_bounds=[-1.0, 1.0], lat_bounds=[-0.5, 0.5]\n",
     ")\n",
     "relhum_subset.plot.polygons(rasterize=True)"
    ],


### PR DESCRIPTION
Adjusts bounding box subsetting parameters to avoid returning an empty array that triggers a ValueError (see uxarray/uxarray#1285) and causes a CI failure.

Closes #28 
